### PR TITLE
Base preset: Pin GitHub action digests to SemVer comments

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -1,5 +1,5 @@
 {
-  extends: ['config:recommended'],
+  extends: ['config:recommended', 'helpers:pinGitHubActionDigestsToSemver'],
   timezone: 'Europe/Zurich',
   schedule: ['after 5pm on the last day of the month', 'on the first day of the month'],
   labels: ['dependencies'],
@@ -17,10 +17,6 @@
     schedule: ['after 5pm on the last day of the month', 'on the first day of the month'],
   },
   packageRules: [
-    /** Pin GitHub `action` digests with full SemVer comments */
-    {
-      extends: ['helpers:pinGitHubActionDigestsToSemver'],
-    },
     /** Only LTS version of Node */
     {
       matchDepNames: ['node'],

--- a/base.json5
+++ b/base.json5
@@ -17,6 +17,10 @@
     schedule: ['after 5pm on the last day of the month', 'on the first day of the month'],
   },
   packageRules: [
+    /** Pin GitHub `action` digests with full SemVer comments */
+    {
+      extends: ['helpers:pinGitHubActionDigestsToSemver'],
+    },
     /** Only LTS version of Node */
     {
       matchDepNames: ['node'],


### PR DESCRIPTION
## Summary
- add `helpers:pinGitHubActionDigestsToSemver` in `base.json5` `packageRules`
- enforce full `major.minor.patch` tag comments for pinned GitHub `action` digests
- avoid shortest-tag normalization (`v9`) when `v9.0.0` is preferred