### PR TITLE
Fix LTS version rules in base.json5

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -20,19 +20,12 @@
     /** Only LTS version of Node */
     {
       matchDepNames: ['node'],
-      allowedVersions: '/[13579]$/',
-      enabled: false,
+      allowedVersions: '/^[02468]\\d*$/',
     },
     /** Only LTS Ubuntu versions */
     {
       matchPackageNames: ['ubuntu'],
-      enabled: false,
-      allowedVersions: '/\.10$/',
-    },
-    {
-      matchPackageNames: ['ubuntu'],
-      enabled: false,
-      allowedVersions: '/.*[13579]\.04$/',
+      allowedVersions: '/^[02468]\\d\\.04$/',
     },
   ],
 }


### PR DESCRIPTION
## Problem

The `base.json5` preset had three rules with `enabled: false` on `matchPackageNames: ['ubuntu']` and `matchDepNames: ['node']`, which **completely disabled** version updates for these packages instead of filtering to LTS versions only.

The `allowedVersions` regex patterns were also inverted — they were written as blacklists (matching non-LTS versions) but Renovate's `allowedVersions` is a **whitelist**.

## Changes

- `Node`: removed `enabled: false`, whitelist now matches even major versions (`/^[02468]\\d*$/` → 18, 20, 22...)
- `Ubuntu`: removed `enabled: false`, consolidated two rules into one, whitelist now matches even-year .04 versions (`/^[02468]\\d\\.04$/` → 20.04, 22.04, 24.04...)

## Impact

Renovate will now properly detect and propose updates for `FROM ubuntu:24.04` in Dockerfiles, automatically upgrading to the next LTS version (e.g. 24.04 → 26.04).