### PR TITLE
Allow c2casgiutils to update to 1.0.0 on stabilization branches

### DIFF
--- a/stabilization-branches.json5
+++ b/stabilization-branches.json5
@@ -17,6 +17,15 @@
       ],
       enabled: false,
     },
+    /** Allow c2casgiutils to update to 1.0.0 on stabilization branches */
+    {
+      matchBaseBranches: ['!master', '!main', '!test', '!int-*'],
+      matchDepNames: ['c2casgiutils'],
+      matchCurrentVersion: '<1.0.0',
+      allowedVersions: '<=1.0.0',
+      enabled: true,
+      schedule: ['before 6am'],
+    },
     /** Packages published very recently are not pushed to stabilization branches for security reasons */
     {
       matchBaseBranches: ['!master', '!main', '!test', '!int-*'],


### PR DESCRIPTION
## Summary

Allow c2casgiutils to update to version 1.0.0 even on stabilization branches, where normally only patch updates are accepted.

## Context

On stabilization branches, only patch updates are allowed by default. This change relaxes that rule for c2casgiutils when the current version is below 1.0.0, allowing it to be updated directly to 1.0.0.

## Implementation Details

Added a new package rule in `stabilization-branches.json5` that:
- Matches stabilization branches (`master`, `main`, `test`, `int-*` excluded)
- Matches `c2casgiutils` with current version `<1.0.0`
- Restricts allowed versions to `<=1.0.0`
- Enables the update (overriding the default `patch only` restriction)