### PR TITLE
Differentiate Node version rules for .nvmrc and Docker

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -17,10 +17,17 @@
     schedule: ['after 5pm on the last day of the month', 'on the first day of the month'],
   },
   packageRules: [
-    /** Only LTS version of Node */
+    /** Only LTS major version of Node in .nvmrc */
     {
+      matchDatasources: ['node-version'],
       matchDepNames: ['node'],
       allowedVersions: '/^[02468]\\d*$/',
+    },
+    /** Only LTS version of Node Docker image (x.y.z format) */
+    {
+      matchDatasources: ['docker'],
+      matchDepNames: ['node'],
+      allowedVersions: '/^[02468]\\d+\\.\\d+\\.\\d+$/',
     },
     /** Only LTS Ubuntu versions */
     {


### PR DESCRIPTION
## Summary

Split the Node version rule into two distinct rules to handle .nvmrc and Docker differently.

## Context

- .nvmrc should only accept LTS major versions (e.g. 22)
- Docker container images should accept x.y.z format with LTS (e.g. 22.11.0)

## Implementation Details

- Added `matchDatasources: ['node-version']` to the existing LTS major version rule for .nvmrc
- Created a new rule with `matchDatasources: ['docker']` accepting x.y.z versions with LTS constraint
- Both rules keep the even-first-digit LTS check (`/^[02468]/`)